### PR TITLE
handle read-only stream output

### DIFF
--- a/index.js
+++ b/index.js
@@ -15,15 +15,25 @@ function createStream(transform) {
     var stream = this
 
     if (file.isStream()) {
-      file.contents.pipe(output)
+      if (output.write) {
+        file.contents.pipe(output)
+      }
       file.contents.on('error', stream.emit.bind(stream, 'error'))
       file.contents = output
       this.push(file)
       return next()
     }
 
-    from([contents])
-      .pipe(output)
+    var outputStream;
+    if (output.write) {
+      outputStream = from([contents])
+        .pipe(output);
+    }
+    else {
+      outputStream = output;
+    }
+
+    outputStream
       .pipe(bl(function(err, buffer) {
         if (err) return stream.emit('error', err)
         file.contents = buffer

--- a/test.js
+++ b/test.js
@@ -79,6 +79,33 @@ test('stream streams output a stream', function(t) {
   }).end(file)
 })
 
+test('buffer to read-only streams output a buffer', function(t) {
+  var readStream = fs.createReadStream(__filename)
+  var contents = fs.readFileSync(__filename)
+  var file = new File({ contents: contents })
+
+  transform(function () {
+    return readStream;
+  }).once('end', function() {
+    t.end()
+  }).on('data', function(file) {
+    t.ok(Buffer.isBuffer(file.contents), 'file.contents is a Buffer')
+  }).end(file)
+})
+
+test('stream to read-only streams output a stream', function(t) {
+  var contents = fs.createReadStream(__filename)
+  var file = new File({ contents: contents })
+
+  transform(function () {
+    return contents;
+  }).once('end', function() {
+    t.end()
+  }).on('data', function(file) {
+    t.ok(file.contents instanceof Stream, 'file.contents is a stream!')
+  }).end(file)
+})
+
 test('modifying buffer streams', function(t) {
   var contents = fs.readFileSync(__filename)
   var file = new File({ contents: contents })


### PR DESCRIPTION
I'm not sure if this is within the scope of this module, since this module is about handling transforms.

The gulp recipe mentioned in https://github.com/hughsk/vinyl-transform/issues/7#issue-66129171 relies on stream output from browserify (details https://github.com/substack/node-browserify/issues/1199), which are different streams dependent on the `file.path` argument on the transform function.

Alternatively, I could make another module altogether that accepts readonly streams output from the transform function.

Fixes #7 and #5
