### PR TITLE
swapped 'new-from' for 'from2'

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+.idea
+node_modules

--- a/index.js
+++ b/index.js
@@ -1,5 +1,5 @@
 var through2 = require('through2')
-var from = require('new-from')
+var from = require('from2')
 var bl = require('bl')
 
 module.exports = createStream
@@ -22,7 +22,7 @@ function createStream(transform) {
       return next()
     }
 
-    from([contents])
+    from(contents)
       .pipe(output)
       .pipe(bl(function(err, buffer) {
         if (err) return stream.emit('error', err)

--- a/package.json
+++ b/package.json
@@ -1,13 +1,13 @@
 {
   "name": "vinyl-transform",
   "description": "Use standard text transform streams to write fewer gulp plugins",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "main": "index.js",
   "browser": "index.js",
   "dependencies": {
-    "through2": "~0.4.1",
-    "new-from": "0.0.3",
-    "bl": "~0.7.0"
+    "bl": "~0.7.0",
+    "from2": "^2.3.0",
+    "through2": "~0.4.1"
   },
   "devDependencies": {
     "tape": "~2.3.2",


### PR DESCRIPTION
Your `from2` dependency resolves multiple builds using `gulp.src`.

No longer getting:
```sh
_stream_readable.js:528
    var ret = dest.write(chunk);

TypeError: dest.write is not a function
    at Producer.ondata (_stream_readable.js:528:20)
    at emitOne (events.js:77:13)
    at Producer.emit (events.js:169:7)
    at Producer.Readable.read (_stream_readable.js:360:10)
    at flow (_stream_readable.js:743:26)
    at resume_ (_stream_readable.js:723:3)
    at nextTickCallbackWith2Args (node.js:441:9)
    at process._tickCallback (node.js:355:17)

```

---
I'm currently using this [recipe](https://gist.github.com/indieisaconcept/936dbf33cfc844d87968) with no problems. **NOTE: this is just a opy of the linked recipe, I've added my own transforms and plugins under the transforms comment.**
```js
// this setup assumes you are using gulp-config for file.src & file.dest
// but can be adapted to vanilla easily.

'use strict';

var transform  = require('vinyl-transform'),
    browserify = require('browserify'),
    watchify   = require('watchify'),

    // consider using gulp-load-plugins
    changed    = require('gulp-changed'),
    gif        = require('gulp-if'),
    rename     = require('gulp-rename'),
    uglify     = require('gulp-uglify'),
    _          = require('lodash'),

    // Task defaults
    defaults = _.defaults({}, watchify.args);

module.exports = function (gulp) {
    var watch   = global.watch,
        options = this.options(defaults),
        file    = this.file,
        cache   = {},
        bundler,
        bundle,

        notify = function (filename) {
            gulp.util.log(gulp.util.colors.green('√') + ' ' + filename);
        };

    bundler = function (options) {
        // leverage vinyl-transform to turn
        // readable stream into vinyl object
        return transform(function(filename) {
            // return previous bundle
            if (cache[filename]) {
                return cache[filename].bundle();
            }
            var b = browserify(filename, options);

            // transforms
            b.transform('debowerify');
            // events
            b.on('bundle', notify.bind(null, 'BUNDLE ' + filename));

            if (watch) {
                b = watchify(b);
                // events
                b.on('update', bundle.bind(null, true));
                // cache for use during watch
                cache[filename] = b;
            }
            return b.bundle();
        });
    };

    bundle = function (check) {
        return gulp.src(file.src)
                // don't check on first run ( i.e initialisation )
                // but do for subsequent calls via bundle.on('update')
                .pipe(gif(check, changed(file.dest, {
                   extension: '.js'
                })))
                .pipe(bundler(options))
                .pipe(gulp.dest(file.dest))
                // minification
                .pipe(uglify())
                .pipe(rename({
                    suffix: '.min'
                }))
                .pipe(gulp.dest(file.dest));
    };
    return bundle(!watch);
};
```